### PR TITLE
Apply title/author patch automatically.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 script:
   # Your test script goes here
   - jupyter nbconvert --to latex rosi_py.ipynb
+  - patch < title_author.diff
   - pdflatex rosi_py.tex
   - source deactivate
 

--- a/rosi_py/title_author.diff
+++ b/rosi_py/title_author.diff
@@ -1,0 +1,14 @@
+--- rosi_py.tex	2018-04-18 14:14:39.439388576 -0400
++++ rosi_py.tex	2018-04-18 14:15:29.883386466 -0400
+@@ -141,8 +141,9 @@
+     \def\gt{>}
+     \def\lt{<}
+     % Document parameters
+-    \title{rosi\_py}
+-    
++    \title{Assessing the Safety of Rosiglitazone\\
++    for the Treatment of Type 2 Diabetes}
++    \author{Konstantinos Vamvourellis}
+     
+     
+ 


### PR DESCRIPTION
As documented in the description https://github.com/bayesways/case_studies_Py/pull/7, I still had to take care of patching the `.tex` file (seen as an intermediate output).

For the record, I generated `title_author.diff` with the `diff -u` command.